### PR TITLE
Add vanity cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ The input for the Nonpher is a CSV file each line of which consists of input com
 The output CSV file contains input compound ID, input compound SMILES and output HS compound SMILES.
 The script is issued by the following command:
 ```bash
-python -m nonpher.nonpher [-h] [-H] [INPUT_FILE [OUTPUT_FILE]]
+$ nonpher [-h] [-H] [INPUT_FILE [OUTPUT_FILE]]
 ```
 
 where parameter -H instructs the script to skipping the first line (header) of the input CSV file.
 
 Naturally in/with the right path (where you downloaded Nonpher [NONPHER_REPOSITORY/nonpher]), you can use:
 ```bash
-nonpher.py [-h] [-H] [INPUT_FILE [OUTPUT_FILE]]
+python nonpher.py [-h] [-H] [INPUT_FILE [OUTPUT_FILE]]
 ```
 
 ## Usage in Python

--- a/nonpher/nonpher.py
+++ b/nonpher/nonpher.py
@@ -136,7 +136,7 @@ def complex_nonpher(smiles, max_steps=30, complexity_filter=ComplexityFilter()):
     return None
 
 
-if __name__ == "__main__":
+def main():
     import argparse
     import sys
     parser = argparse.ArgumentParser(description="Nonpher is software for generating hard-to-synthesize structures from"
@@ -162,3 +162,7 @@ if __name__ == "__main__":
             idx, smi = spls[:2]
             morph = complex_nonpher(smi)
             out.write("%s,%s,%s\n" % (idx, smi, morph if morph else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,9 @@ setup(name='nonpher',
       packages=['nonpher',], # 'molpher-lib', 'rdkit'],
       zip_safe=False,
       include_package_data=True,
+      entry_points={
+          'console_scripts': [
+              'nonpher = nonpher.nonpher:main',
+          ],
+      },
      )


### PR DESCRIPTION
Closes #1 

This PR does three things:

1. It encapsulates the script functionality in `nonpher/nonpher.py` found in the `if __name__ == '__main__': ...` block in its own function, `def main(): ...`. The `if __name__ == '__main__':` block now simply calls `main()`. There is no change in functionality.
2. Adds an entrypoint in `setup.py` to automatically generate a CLI tool `nonpher` that points to this `main()` function
3. Update the README to reflect this

Previous usage of `python -m nonpher.nonpher` will continue to work! However, I saw that below the package-based execution of the code, you have a note about using the `nonpher.py` file directly. I would suggest removing this, because this script relies on other code and this is pretty unreliable from user world. 